### PR TITLE
Added verbose option and updated docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,10 @@ Additionally, it has `clean` option for exporting SVG.
 
 - `clean`: Remove Sketch namespaces and metadata from SVG (optional, defaults to NO). See [clean-sketch](https://github.com/overblog/clean-sketch).
 
+For debugging purposes, it has `verbose` option for additional output
+
+- `verbose`: Enables verbose output and outputs stdout from `sketchtool` (optional, defaults to false)
+
 
 ## Layer Naming
 

--- a/coffee/index.coffee
+++ b/coffee/index.coffee
@@ -52,6 +52,11 @@ module.exports = (options = {}) ->
     
     # SketchTool
     program = spawn cmnd, args.concat src, '--output=' + tmp_dir.path
+
+    # Verbose Output
+    if options.verbose
+        program.stdout.on 'data', (data) ->
+            gutil.log(data.toString())
     
     # return data
     program.stdout.on 'end', =>


### PR DESCRIPTION
Added `verbose` option to relay output from `sketchtool` to stdout via `gulp-util`. This fixes #19 